### PR TITLE
Apple Silicon support

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -49,7 +49,9 @@ function createMenubarApp() {
   });
 
   menuBar.on('ready', () => {
-    app.dock.hide();
+    setTimeout(() => {
+      app.dock.hide();
+    }, 1000);
     translateWindow = initTranslateWindow(menuBar);
 
     if (!menuBar.window) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
-    "release": "electron-forge publish",
+    "release": "electron-forge publish --arch x64 && electron-forge publish --arch arm64",
     "lint": "eslint '*/**/*.{js,ts,tsx}' --fix"
   },
   "keywords": [],


### PR DESCRIPTION
Summary of changes:

* Wait for 1 second before hiding the dock icon – without this, the dock icon instantly reappears after app launch, bug seems to only be present on arm64 builds
* Updated the publish script to build for both x64 and arm64

Fixes #7