### PR TITLE
Fix Chinese input method compatibility

### DIFF
--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -48,7 +48,7 @@ class BarTranslate: ObservableObject {
 class AppDelegate: NSObject, NSApplicationDelegate {
   static private(set) var instance: AppDelegate!
   
-  var popover: NSPopover!
+  var panel: NSPanel!
   var statusBarItem: NSStatusItem!
   var hotkeyToggleApp: HotKey!
   var hotkeyToggleSettings: HotKey!
@@ -91,7 +91,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       key: key,
       modifiers: keyToNSEventModifierFlags(key: mod),
       keyDownHandler: {
-        self.togglePopover(nil)
+        self.togglePanel(nil)
       }
     )
   }
@@ -111,44 +111,77 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     let contentView = ContentView(BT: BT)
     
-    // Application Bubble
-    let popover = NSPopover()
-    popover.contentSize = NSSize(width: Constants.AppSize.width, height: Constants.AppSize.height)
-    popover.behavior = .transient
-    popover.contentViewController = NSHostingController(rootView: contentView)
-    self.popover = popover
-    
-    // Do not auto close popover when debugging
-    #if DEBUG
-    popover.behavior = .applicationDefined
-    #endif
-
+    // Application Panel
+    let panel = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: Constants.AppSize.width, height: Constants.AppSize.height),
+      styleMask: [.titled, .fullSizeContentView],
+      backing: .buffered,
+      defer: false)
+    panel.isFloatingPanel = true
+    panel.level = .floating
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    panel.contentViewController = NSHostingController(rootView: contentView)
+    panel.isMovableByWindowBackground = false
+    panel.backgroundColor = .clear
+    panel.titleVisibility = .hidden
+    panel.titlebarAppearsTransparent = true
+    panel.standardWindowButton(.closeButton)?.isHidden = true
+    panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+    panel.standardWindowButton(.zoomButton)?.isHidden = true
+    panel.hasShadow = true
+    panel.delegate = self
+    self.panel = panel
     
     // Setup status bar item
     self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
     if let button = self.statusBarItem.button {
       button.image = NSImage(named: menuBarIcon.id)
-      button.action = #selector(togglePopover(_:))
+      button.action = #selector(togglePanel(_:))
     }
     
     setupToggleAppHotkeys()
   }
   
-  // Show or hide BarTranslate
-  @objc func togglePopover(_ sender: AnyObject?) {
-    
-    if let button = self.statusBarItem.button {
-      if self.popover.isShown {
-        self.popover.performClose(sender)
-      } else {
-        self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
-        
-        // Autofocus HTML input
-        if let webView = BT.webView, !webView.isHidden {
-          injectFocusScript(webView: webView, provider: translationProvider)
-        }
+  // Show or hide BarTranslate panel
+  @objc func togglePanel(_ sender: AnyObject?) {
+    if panel.isVisible {
+      panel.orderOut(sender)
+    } else {
+      positionPanel()
+      panel.makeKeyAndOrderFront(sender)
+      NSApp.activate(ignoringOtherApps: true)
+      
+      // Autofocus HTML input
+      if let webView = BT.webView, !webView.isHidden {
+        injectFocusScript(webView: webView, provider: translationProvider)
       }
     }
   }
+  
+  func positionPanel() {
+    guard let button = statusBarItem.button else { return }
+    guard let window = button.window else { return }
+    
+    // Convert button frame to screen coordinates
+    let buttonFrame = window.convertToScreen(button.convert(button.bounds, to: nil))
+    let panelSize = panel.frame.size
+    
+    // Position panel centered below the menu bar icon
+    let panelX = buttonFrame.midX - (panelSize.width / 2)
+    let panelY = buttonFrame.minY - panelSize.height - 5  // 5pt gap
+    
+    panel.setFrameOrigin(NSPoint(x: panelX, y: panelY))
+  }
+  
+  func panelDidResignKey(_ notification: Notification) {
+    panel.orderOut(nil)
+  }
 }
 
+extension AppDelegate: NSWindowDelegate {
+  func windowDidResignKey(_ notification: Notification) {
+    if let window = notification.object as? NSPanel, window == panel {
+      panelDidResignKey(notification)
+    }
+  }
+}


### PR DESCRIPTION
### Problem
`NSPopover` does not correctly display the Input Method Editor (IME) candidate window for Chinese and other East Asian input methods, making reliable text input impossible.

### Solution
Replaced `NSPopover` with `NSPanel` while preserving the existing user experience:
- Panel appears directly beneath the menu bar icon
- Automatically dismisses when clicking outside
- Retains original visual styling

### Changes Made
- Replaced `NSPopover` with `NSPanel` in `BarTranslateApp.swift`
- Implemented a custom `positionPanel()` method to anchor the panel to the menu bar
- Added `NSWindowDelegate` to manage auto-dismiss behavior
- Preserved all existing functionality and visual appearance
- Enabled panel dragging; position resets when the panel is closed and reopened

### Testing
- Verified proper IME behavior with Chinese input methods
- Confirmed all existing features remain functional (hotkeys, settings, translations)

### Known Issues & Future Improvements
- An unexplained extra top padding is added in the window
- Consider adding a pin button next to **BarTranslate**, spaced away from less frequently used controls (Quit, Settings). This would complement the draggable panel and improve workflow usability.