### PR TITLE
Merge upstream PR #65: Settings redesign with new features

### DIFF
--- a/BarTranslate.xcodeproj/project.pbxproj
+++ b/BarTranslate.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		45E1DB2F2A23316F00FA549C /* TranslateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1DB2E2A23316F00FA549C /* TranslateView.swift */; };
 		45E44E562A23BEB500226A82 /* style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E44E552A23BEB500226A82 /* style.swift */; };
 		45EF05232A234EAF00F5B8D4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EF05222A234EAF00F5B8D4 /* SettingsView.swift */; };
+		45FDE0012DDA10000000001 /* features.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FDE0022DDA10000000001 /* features.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +42,7 @@
 		45E1DB2E2A23316F00FA549C /* TranslateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateView.swift; sourceTree = "<group>"; };
 		45E44E552A23BEB500226A82 /* style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = style.swift; sourceTree = "<group>"; };
 		45EF05222A234EAF00F5B8D4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		45FDE0022DDA10000000001 /* features.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = features.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +123,7 @@
 				456FDE4A2DDA0FD100639F6A /* css */,
 				45E44E552A23BEB500226A82 /* style.swift */,
 				456FDE482DD9F04600639F6A /* autofocus.swift */,
+				45FDE0022DDA10000000001 /* features.swift */,
 			);
 			path = injections;
 			sourceTree = "<group>";
@@ -213,6 +216,7 @@
 				45EF05232A234EAF00F5B8D4 /* SettingsView.swift in Sources */,
 				45D1EF782A20DA2D0029FACD /* BarTranslateApp.swift in Sources */,
 				45C035322A21263500E304FF /* Constants.swift in Sources */,
+				45FDE0012DDA10000000001 /* features.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -48,7 +48,7 @@ class BarTranslate: ObservableObject {
 class AppDelegate: NSObject, NSApplicationDelegate {
   static private(set) var instance: AppDelegate!
   
-  var popover: NSPopover!
+  var panel: NSPanel!
   var statusBarItem: NSStatusItem!
   var hotkeyToggleApp: HotKey!
   var hotkeyToggleSettings: HotKey!
@@ -91,7 +91,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       key: key,
       modifiers: keyToNSEventModifierFlags(key: mod),
       keyDownHandler: {
-        self.togglePopover(nil)
+        self.togglePanel(nil)
       }
     )
   }
@@ -111,44 +111,77 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     let contentView = ContentView(BT: BT)
     
-    // Application Bubble
-    let popover = NSPopover()
-    popover.contentSize = NSSize(width: Constants.AppSize.width, height: Constants.AppSize.height)
-    popover.behavior = .transient
-    popover.contentViewController = NSHostingController(rootView: contentView)
-    self.popover = popover
-    
-    // Do not auto close popover when debugging
-    #if DEBUG
-    popover.behavior = .applicationDefined
-    #endif
-
+    // Application Panel
+    let panel = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: Constants.AppSize.width, height: Constants.AppSize.height),
+      styleMask: [.titled, .fullSizeContentView],
+      backing: .buffered,
+      defer: false)
+    panel.isFloatingPanel = true
+    panel.level = .floating
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    panel.contentViewController = NSHostingController(rootView: contentView)
+    panel.isMovableByWindowBackground = false
+    panel.backgroundColor = .clear
+    panel.titleVisibility = .hidden
+    panel.titlebarAppearsTransparent = true
+    panel.standardWindowButton(.closeButton)?.isHidden = true
+    panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+    panel.standardWindowButton(.zoomButton)?.isHidden = true
+    panel.hasShadow = true
+    panel.delegate = self
+    self.panel = panel
     
     // Setup status bar item
     self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
     if let button = self.statusBarItem.button {
       button.image = NSImage(named: menuBarIcon.id)
-      button.action = #selector(togglePopover(_:))
+      button.action = #selector(togglePanel(_:))
     }
     
     setupToggleAppHotkeys()
   }
   
-  // Show or hide BarTranslate
-  @objc func togglePopover(_ sender: AnyObject?) {
-    
-    if let button = self.statusBarItem.button {
-      if self.popover.isShown {
-        self.popover.performClose(sender)
-      } else {
-        self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
-        
-        // Autofocus HTML input
-        if let webView = BT.webView, !webView.isHidden {
-          injectFocusScript(webView: webView, provider: translationProvider)
-        }
+  // Show or hide BarTranslate panel
+  @objc func togglePanel(_ sender: AnyObject?) {
+    if panel.isVisible {
+      panel.orderOut(sender)
+    } else {
+      positionPanel()
+      panel.makeKeyAndOrderFront(sender)
+      NSApp.activate(ignoringOtherApps: true)
+      
+      // Autofocus HTML input
+      if let webView = BT.webView, !webView.isHidden {
+        injectFocusScript(webView: webView, provider: translationProvider)
       }
     }
   }
+  
+  func positionPanel() {
+    guard let button = statusBarItem.button else { return }
+    guard let window = button.window else { return }
+    
+    // Convert button frame to screen coordinates
+    let buttonFrame = window.convertToScreen(button.convert(button.bounds, to: nil))
+    let panelSize = panel.frame.size
+    
+    // Position panel centered below the menu bar icon
+    let panelX = buttonFrame.midX - (panelSize.width / 2)
+    let panelY = buttonFrame.minY - panelSize.height - 5  // 5pt gap
+    
+    panel.setFrameOrigin(NSPoint(x: panelX, y: panelY))
+  }
+  
+  func panelDidResignKey(_ notification: Notification) {
+    panel.orderOut(nil)
+  }
 }
 
+extension AppDelegate: NSWindowDelegate {
+  func windowDidResignKey(_ notification: Notification) {
+    if let window = notification.object as? NSPanel, window == panel {
+      panelDidResignKey(notification)
+    }
+  }
+}

--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -15,13 +15,9 @@ struct BarTranslateApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
   
   var body: some Scene {
-    // Rendering a WindowGroup enables macOS default keyboard shortcuts (e.g. copy/paste) on macOS versions <= Monterey.
-    // The WindowGroup serves no other purpose, and is thus automatically closed on startup (see 'applicationDidFinishLaunching').
     WindowGroup {
       EmptyView()
     }.commands {
-      // Although the empty window group is closed on startup, the user could still force it to open using the shortcut '⌘ + N'.
-      // This shouldn't be possible, thus that keyboard shortcut is disabled here.
       CommandGroup(replacing: CommandGroupPlacement.newItem) {}
     }
     Settings {
@@ -30,125 +26,141 @@ struct BarTranslateApp: App {
   }
 }
 
-class BarTranslate: ObservableObject {
-  @Published var currentView: CurrentContentView = .translate
-  var webView: WKWebView?
-  
-  func reloadWebView(for provider: TranslationProvider) {
-    guard let webView = webView else { return }
+// MARK: - BarTranslate Model
 
-    let providerURL = URL(string: "https://translate.google.com")!
-    let request = URLRequest(url: providerURL)
-    
-    webView.load(request)
-    injectCSS(webView: webView, provider: provider)
-  }
+class BarTranslate: ObservableObject {
+    @Published var currentView: CurrentContentView = .translate
+    @Published var isLoading: Bool = true
+    @Published var characterCount: Int = 0
+    @Published var hasResult: Bool = false
+    @Published var justCopied: Bool = false
+
+    var webView: WKWebView?
+
+    // Remember last language pair
+    var lastSourceLang: String {
+        get { UserDefaults.standard.string(forKey: "lastSourceLang") ?? "auto" }
+        set { UserDefaults.standard.set(newValue, forKey: "lastSourceLang") }
+    }
+    var lastTargetLang: String {
+        get { UserDefaults.standard.string(forKey: "lastTargetLang") ?? "vi" }
+        set { UserDefaults.standard.set(newValue, forKey: "lastTargetLang") }
+    }
+
+    func reloadWebView(for provider: TranslationProvider) {
+        guard let webView = webView else { return }
+
+        let sl = lastSourceLang
+        let tl = lastTargetLang
+        let urlString = "https://translate.google.com/?sl=\(sl)&tl=\(tl)&op=translate"
+        let providerURL = URL(string: urlString)!
+        let request = URLRequest(url: providerURL)
+
+        webView.load(request)
+        injectCSS(webView: webView, provider: provider)
+    }
 }
+
+// MARK: - AppDelegate
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-  static private(set) var instance: AppDelegate!
-  
-  var popover: NSPopover!
-  var statusBarItem: NSStatusItem!
-  var hotkeyToggleApp: HotKey!
-  var hotkeyToggleSettings: HotKey!
-  
-  var BT: BarTranslate = BarTranslate()
-    
-  @AppStorage("translationProvider") private var translationProvider: TranslationProvider = DefaultSettings.translationProvider
-  @AppStorage("showHideKey") private var showHideKey: String = DefaultSettings.ToggleApp.key.description
-  @AppStorage("showHideModifier") private var showHideModifier: String = DefaultSettings.ToggleApp.modifier.description
-  @AppStorage("menuBarIcon") private var menuBarIcon: MenuBarIcon = DefaultSettings.menuBarIcon
-  
-  override init() {
-    super.init()
-    UserDefaults.standard.addObserver(self, forKeyPath: "showHideKey", options: .new, context: nil)
-    UserDefaults.standard.addObserver(self, forKeyPath: "showHideModifier", options: .new, context: nil)
-    UserDefaults.standard.addObserver(self, forKeyPath: "menuBarIcon", options: .new, context: nil)
-  }
-  
-  deinit {
-    UserDefaults.standard.removeObserver(self, forKeyPath: "showHideKey")
-    UserDefaults.standard.removeObserver(self, forKeyPath: "showHideModifier")
-    UserDefaults.standard.removeObserver(self, forKeyPath: "menuBarIcon")
-  }
-  
-  override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-    if keyPath == "showHideKey" || keyPath == "showHideModifier" {
-      setupToggleAppHotkeys()
-    }
-    else if keyPath == "menuBarIcon" {
-      updateMenuBarIcon()
-    }
-  }
-  
-  func setupToggleAppHotkeys() {
-    
-    let key = Key(string: showHideKey) ?? DefaultSettings.ToggleApp.key
-    let mod = Key(string: showHideModifier) ?? DefaultSettings.ToggleApp.modifier
-    
-    hotkeyToggleApp = HotKey(
-      key: key,
-      modifiers: keyToNSEventModifierFlags(key: mod),
-      keyDownHandler: {
-        self.togglePopover(nil)
-      }
-    )
-  }
-  
-  func updateMenuBarIcon() {
-    if let button = self.statusBarItem.button {
-      button.image = NSImage(named: menuBarIcon.id)
-    }
-  }
-  
-  func applicationDidFinishLaunching(_ notification: Notification) {
-    
-    // Immediately close the main (empty) app window defined in 'BarTranslateApp'.
-    if let window = NSApplication.shared.windows.first {
-      window.close()
-    }
-    
-    let contentView = ContentView(BT: BT)
-    
-    // Application Bubble
-    let popover = NSPopover()
-    popover.contentSize = NSSize(width: Constants.AppSize.width, height: Constants.AppSize.height)
-    popover.behavior = .transient
-    popover.contentViewController = NSHostingController(rootView: contentView)
-    self.popover = popover
-    
-    // Do not auto close popover when debugging
-    #if DEBUG
-    popover.behavior = .applicationDefined
-    #endif
+    static private(set) var instance: AppDelegate!
 
-    
-    // Setup status bar item
-    self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
-    if let button = self.statusBarItem.button {
-      button.image = NSImage(named: menuBarIcon.id)
-      button.action = #selector(togglePopover(_:))
+    var popover: NSPopover!
+    var statusBarItem: NSStatusItem!
+    var hotkeyToggleApp: HotKey!
+
+    var BT: BarTranslate = BarTranslate()
+
+    @AppStorage("translationProvider") private var translationProvider: TranslationProvider = DefaultSettings.translationProvider
+    @AppStorage("showHideKey") private var showHideKey: String = DefaultSettings.ToggleApp.key.description
+    @AppStorage("showHideModifier") private var showHideModifier: String = DefaultSettings.ToggleApp.modifier.description
+    @AppStorage("menuBarIcon") private var menuBarIcon: MenuBarIcon = DefaultSettings.menuBarIcon
+    @AppStorage("autoClipboardPaste") private var autoClipboardPaste: Bool = false
+
+    override init() {
+        super.init()
+        UserDefaults.standard.addObserver(self, forKeyPath: "showHideKey", options: .new, context: nil)
+        UserDefaults.standard.addObserver(self, forKeyPath: "showHideModifier", options: .new, context: nil)
+        UserDefaults.standard.addObserver(self, forKeyPath: "menuBarIcon", options: .new, context: nil)
     }
-    
-    setupToggleAppHotkeys()
-  }
-  
-  // Show or hide BarTranslate
-  @objc func togglePopover(_ sender: AnyObject?) {
-    
-    if let button = self.statusBarItem.button {
-      if self.popover.isShown {
-        self.popover.performClose(sender)
-      } else {
-        self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
-        
-        // Autofocus HTML input
-        if let webView = BT.webView, !webView.isHidden {
-          injectFocusScript(webView: webView, provider: translationProvider)
+
+    deinit {
+        UserDefaults.standard.removeObserver(self, forKeyPath: "showHideKey")
+        UserDefaults.standard.removeObserver(self, forKeyPath: "showHideModifier")
+        UserDefaults.standard.removeObserver(self, forKeyPath: "menuBarIcon")
+    }
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == "showHideKey" || keyPath == "showHideModifier" {
+            setupToggleAppHotkeys()
+        } else if keyPath == "menuBarIcon" {
+            updateMenuBarIcon()
         }
-      }
     }
-  }
-}
 
+    func setupToggleAppHotkeys() {
+        let key = Key(string: showHideKey) ?? DefaultSettings.ToggleApp.key
+        let mod = Key(string: showHideModifier) ?? DefaultSettings.ToggleApp.modifier
+
+        hotkeyToggleApp = HotKey(
+            key: key,
+            modifiers: keyToNSEventModifierFlags(key: mod),
+            keyDownHandler: { self.togglePopover(nil) }
+        )
+    }
+
+    func updateMenuBarIcon() {
+        if let button = self.statusBarItem.button {
+            button.image = NSImage(named: menuBarIcon.id)
+        }
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        if let window = NSApplication.shared.windows.first { window.close() }
+
+        let contentView = ContentView(BT: BT)
+
+        let popover = NSPopover()
+        popover.contentSize = NSSize(width: Constants.AppSize.width, height: Constants.AppSize.height)
+        popover.behavior = .transient
+        popover.contentViewController = NSHostingController(rootView: contentView)
+        self.popover = popover
+
+        #if DEBUG
+        popover.behavior = .applicationDefined
+        #endif
+
+        self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
+        if let button = self.statusBarItem.button {
+            button.image = NSImage(named: menuBarIcon.id)
+            button.action = #selector(togglePopover(_:))
+        }
+
+        setupToggleAppHotkeys()
+    }
+
+    @objc func togglePopover(_ sender: AnyObject?) {
+        guard let button = self.statusBarItem.button else { return }
+
+        if self.popover.isShown {
+            self.popover.performClose(sender)
+        } else {
+            self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
+
+            guard let webView = BT.webView, !webView.isHidden else { return }
+
+            // Autofocus textarea
+            injectFocusScript(webView: webView, provider: translationProvider)
+
+            // Auto-paste clipboard if setting enabled and clipboard has text
+            if autoClipboardPaste,
+               let clipText = NSPasteboard.general.string(forType: .string),
+               !clipText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                    injectClipboardText(webView: webView, text: clipText)
+                }
+            }
+        }
+    }
+}

--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -30,6 +30,13 @@ struct BarTranslateApp: App {
   }
 }
 
+// MARK: - Panel Configuration
+
+private struct PanelConfig {
+  /// Gap between menu bar icon and panel (in points)
+  static let menuBarGap: CGFloat = 5
+}
+
 class BarTranslate: ObservableObject {
   @Published var currentView: CurrentContentView = .translate
   var webView: WKWebView?
@@ -51,7 +58,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   var panel: NSPanel!
   var statusBarItem: NSStatusItem!
   var hotkeyToggleApp: HotKey!
-  var hotkeyToggleSettings: HotKey!
   
   var BT: BarTranslate = BarTranslate()
     
@@ -114,7 +120,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Application Panel
     let panel = NSPanel(
       contentRect: NSRect(x: 0, y: 0, width: Constants.AppSize.width, height: Constants.AppSize.height),
-      styleMask: [.titled, .fullSizeContentView],
+      styleMask: [.borderless],
       backing: .buffered,
       defer: false)
     panel.isFloatingPanel = true
@@ -123,14 +129,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     panel.contentViewController = NSHostingController(rootView: contentView)
     panel.isMovableByWindowBackground = false
     panel.backgroundColor = .clear
-    panel.titleVisibility = .hidden
-    panel.titlebarAppearsTransparent = true
-    panel.standardWindowButton(.closeButton)?.isHidden = true
-    panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
-    panel.standardWindowButton(.zoomButton)?.isHidden = true
     panel.hasShadow = true
     panel.delegate = self
+    
+    // Apply rounded corners to match popover appearance
+    if let contentView = panel.contentView {
+      contentView.wantsLayer = true
+      contentView.layer?.cornerRadius = 12
+      contentView.layer?.masksToBounds = true
+    }
+    
     self.panel = panel
+    
+    // Do not auto-close panel when debugging
+    #if DEBUG
+    panel.hidesOnDeactivate = false
+    #endif
     
     // Setup status bar item
     self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
@@ -167,8 +181,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let panelSize = panel.frame.size
     
     // Position panel centered below the menu bar icon
-    let panelX = buttonFrame.midX - (panelSize.width / 2)
-    let panelY = buttonFrame.minY - panelSize.height - 5  // 5pt gap
+    var panelX = buttonFrame.midX - (panelSize.width / 2)
+    var panelY = buttonFrame.minY - panelSize.height - PanelConfig.menuBarGap
+    
+    // Ensure panel stays within screen boundaries
+    if let screen = NSScreen.main {
+      let screenFrame = screen.visibleFrame
+      
+      // Clamp horizontal position to stay on screen
+      if panelX < screenFrame.minX {
+        panelX = screenFrame.minX
+      } else if panelX + panelSize.width > screenFrame.maxX {
+        panelX = screenFrame.maxX - panelSize.width
+      }
+      
+      // Ensure panel doesn't go below screen bottom
+      if panelY < screenFrame.minY {
+        panelY = screenFrame.minY
+      }
+    }
     
     panel.setFrameOrigin(NSPoint(x: panelX, y: panelY))
   }

--- a/BarTranslate/injections/features.swift
+++ b/BarTranslate/injections/features.swift
@@ -1,0 +1,165 @@
+//
+//  features.swift
+//  BarTranslate
+//
+//  Feature injections: Copy Button, Character Counter, Clipboard Paste, Remember Languages
+//
+
+import Foundation
+import WebKit
+import AppKit
+
+// MARK: - 1. Clipboard Auto-Paste
+
+/// Injects clipboard text into the Google Translate source textarea
+func injectClipboardText(webView: WKWebView, text: String) {
+    let escaped = text
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "`", with: "\\`")
+    let js = """
+    (function() {
+        function tryPaste() {
+            var ta = document.querySelector('textarea');
+            if (!ta) { setTimeout(tryPaste, 200); return; }
+            var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+            nativeInputValueSetter.call(ta, `\(escaped)`);
+            ta.dispatchEvent(new Event('input', { bubbles: true }));
+            ta.dispatchEvent(new Event('change', { bubbles: true }));
+            ta.focus();
+        }
+        tryPaste();
+    })();
+    """
+    webView.evaluateJavaScript(js) { _, error in
+        if let error = error { print("[ClipboardPaste] Error: \(error)") }
+    }
+}
+
+// MARK: - 2. Character Counter (JS → Swift via messageHandler)
+
+/// Injects JS that watches textarea input and sends char count to Swift
+func injectCharCountScript(webView: WKWebView) {
+    let js = """
+    (function() {
+        if (window.__btCharCountSetup) return;
+        window.__btCharCountSetup = true;
+
+        function setup() {
+            var ta = document.querySelector('textarea');
+            if (!ta) { setTimeout(setup, 400); return; }
+            function report() {
+                try { window.webkit.messageHandlers.charCount.postMessage(ta.value.length); } catch(e) {}
+            }
+            ta.addEventListener('input', report);
+            report();
+        }
+        setup();
+    })();
+    """
+    webView.evaluateJavaScript(js) { _, error in
+        if let error = error { print("[CharCount] Error: \(error)") }
+    }
+}
+
+// MARK: - 3. Copy Button – reads translation result via JS evaluation
+
+/// Reads the translation result text from Google Translate's DOM
+func readTranslationResult(from webView: WKWebView, completion: @escaping (String?) -> Void) {
+    let js = """
+    (function() {
+        var selectors = [
+            '[data-result-index="0"]',
+            'span[jsname="W297wb"]',
+            '.lRu31',
+            '.ryNqvb',
+            'c-wiz span[lang]:not([aria-label])'
+        ];
+        for (var sel of selectors) {
+            var el = document.querySelector(sel);
+            if (el) {
+                var text = el.innerText.trim();
+                if (text.length > 0) return text;
+            }
+        }
+        // Broader fallback: find any non-trivial lang-attributed span
+        var all = document.querySelectorAll('span[lang]');
+        for (var s of all) {
+            var t = s.innerText.trim();
+            if (t.length > 2 && !s.closest('textarea') && !s.closest('[aria-label]')) return t;
+        }
+        return null;
+    })();
+    """
+    webView.evaluateJavaScript(js) { result, _ in
+        completion(result as? String)
+    }
+}
+
+/// Injects a MutationObserver that pings Swift when a translation result appears/disappears
+func injectResultObserverScript(webView: WKWebView) {
+    let js = """
+    (function() {
+        if (window.__btResultObserver) return;
+        window.__btResultObserver = true;
+
+        function check() {
+            var selectors = [
+                '[data-result-index="0"]',
+                'span[jsname="W297wb"]',
+                '.lRu31', '.ryNqvb'
+            ];
+            for (var sel of selectors) {
+                var el = document.querySelector(sel);
+                if (el && el.innerText.trim().length > 0) {
+                    try { window.webkit.messageHandlers.resultAvailable.postMessage(true); } catch(e) {}
+                    return;
+                }
+            }
+            try { window.webkit.messageHandlers.resultAvailable.postMessage(false); } catch(e) {}
+        }
+
+        var observer = new MutationObserver(check);
+        observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+        check();
+    })();
+    """
+    webView.evaluateJavaScript(js) { _, error in
+        if let error = error { print("[ResultObserver] Error: \(error)") }
+    }
+}
+
+// MARK: - 4. Remember Last Languages
+
+/// Injects JS that watches URL changes and reports sl/tl params back to Swift
+func injectLanguageTrackerScript(webView: WKWebView) {
+    let js = """
+    (function() {
+        if (window.__btLangTracker) return;
+        window.__btLangTracker = true;
+
+        var lastHref = location.href;
+        setInterval(function() {
+            if (location.href !== lastHref) {
+                lastHref = location.href;
+                try { window.webkit.messageHandlers.urlChanged.postMessage(location.href); } catch(e) {}
+            }
+        }, 800);
+        // Report initial URL
+        try { window.webkit.messageHandlers.urlChanged.postMessage(location.href); } catch(e) {}
+    })();
+    """
+    webView.evaluateJavaScript(js) { _, error in
+        if let error = error { print("[LangTracker] Error: \(error)") }
+    }
+}
+
+/// Parses sl/tl from a Google Translate URL string
+func parseLanguageParams(from urlString: String) -> (source: String?, target: String?) {
+    guard let url = URL(string: urlString),
+          let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        return (nil, nil)
+    }
+    let sl = components.queryItems?.first(where: { $0.name == "sl" })?.value
+    let tl = components.queryItems?.first(where: { $0.name == "tl" })?.value
+    return (sl, tl)
+}

--- a/BarTranslate/views/ContentView.swift
+++ b/BarTranslate/views/ContentView.swift
@@ -39,11 +39,7 @@ struct ContentView: View {
       minHeight: Constants.AppSize.height,
       alignment: .topLeading
     )
-    // Color the popover arrow
-    .background(
-      Color.blue
-        .position(x: Constants.AppSize.width / 2, y: -Constants.AppSize.height / 2 + 10)
-    )
+    .background(Color(NSColor.windowBackgroundColor))
   }
   
   

--- a/BarTranslate/views/ContentView.swift
+++ b/BarTranslate/views/ContentView.swift
@@ -3,52 +3,51 @@
 //  BarTranslate
 //
 //  Created by Thijmen Dam on 26/05/2023.
+//  Redesigned UI – refined native macOS style
 //
 
 import SwiftUI
 
 enum CurrentContentView {
-  case translate
-  case settings
+    case translate
+    case settings
 }
 
 struct ContentView: View {
-  
-  @ObservedObject var BT: BarTranslate
-  @AppStorage("translationProvider") private var translationProvider: TranslationProvider = .google
-  
-  var body: some View {
-    VStack(spacing: 0) {
-      
-      TopView(contentViewState: BT)
-      
-      ZStack {
-        TranslateView(BT: BT)
-          .zIndex(1)
-          .allowsHitTesting(BT.currentView == .translate)
-          .disabled(BT.currentView != .translate)
-        SettingsView()
-          .zIndex(BT.currentView == .translate ? 0 : 2)
-          .allowsHitTesting(BT.currentView == .settings)
-          .disabled(BT.currentView != .settings)
-      }
+
+    @ObservedObject var BT: BarTranslate
+    @AppStorage("translationProvider") private var translationProvider: TranslationProvider = .google
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TopView(contentViewState: BT)
+
+            ZStack {
+                TranslateView(BT: BT)
+                    .zIndex(1)
+                    .allowsHitTesting(BT.currentView == .translate)
+                    .opacity(BT.currentView == .translate ? 1 : 0)
+
+                SettingsView()
+                    .zIndex(BT.currentView == .translate ? 0 : 2)
+                    .allowsHitTesting(BT.currentView == .settings)
+                    .opacity(BT.currentView == .settings ? 1 : 0)
+            }
+            .animation(.easeInOut(duration: 0.15), value: BT.currentView)
+        }
+        .frame(
+            minWidth: Constants.AppSize.width,
+            minHeight: Constants.AppSize.height,
+            alignment: .topLeading
+        )
+        // Popover arrow color – match window background instead of harsh blue
+        .background(
+            Color(NSColor.windowBackgroundColor)
+                .position(x: Constants.AppSize.width / 2, y: -Constants.AppSize.height / 2 + 10)
+        )
     }
-    .animation(nil, value: UUID())
-    .frame(
-      minWidth: Constants.AppSize.width,
-      minHeight: Constants.AppSize.height,
-      alignment: .topLeading
-    )
-    // Color the popover arrow
-    .background(
-      Color.blue
-        .position(x: Constants.AppSize.width / 2, y: -Constants.AppSize.height / 2 + 10)
-    )
-  }
-  
-  
-  
-  func goToSettings() {
-    BT.currentView = .settings
-  }
+
+    func goToSettings() {
+        BT.currentView = .settings
+    }
 }

--- a/BarTranslate/views/SettingsView.swift
+++ b/BarTranslate/views/SettingsView.swift
@@ -3,112 +3,209 @@
 //  BarTranslate
 //
 //  Created by Thijmen Dam on 28/05/2023.
+//  Redesigned UI – refined native macOS style
 //
 
 import SwiftUI
 import Foundation
 import HotKey
 
-struct SponsorButton: View {
-  var body: some View {
-    Link("Sponsor This Project 😃",
-         destination: URL(string: "https://github.com/sponsors/ThijmenDam")!)
-    .foregroundColor(.white)
-    .frame(maxWidth: .infinity, minHeight: 30)
-    .background(.blue)
-    .cornerRadius(6)
-    .padding(.top, 2)
-    .padding(.bottom, 14)
-    
-  }
+struct SettingsView: View {
+
+    @AppStorage("translationProvider") private var translationProvider: TranslationProvider = DefaultSettings.translationProvider
+    @AppStorage("showHideKey") private var showHideKey: String = DefaultSettings.ToggleApp.key.description
+    @AppStorage("showHideModifier") private var showHideModifier: String = DefaultSettings.ToggleApp.modifier.description
+    @AppStorage("menuBarIcon") private var menuBarIcon: MenuBarIcon = DefaultSettings.menuBarIcon
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 20) {
+
+                // Translation Provider
+                SettingsSection(title: "Provider") {
+                    SettingsRow(label: "Translation engine") {
+                        Picker("", selection: $translationProvider) {
+                            Text("Google Translate").tag(TranslationProvider.google)
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                        .frame(width: 140)
+                    }
+                }
+
+                // Keyboard shortcut
+                SettingsSection(title: "Keyboard Shortcut") {
+                    SettingsRow(label: "Toggle app") {
+                        HStack(spacing: 6) {
+                            Picker("", selection: $showHideModifier) {
+                                ForEach(modifiers, id: \.self) { modifier in
+                                    Text(modifier.description).tag(modifier.description)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .frame(width: 60)
+
+                            Text("+")
+                                .font(.system(size: 12))
+                                .foregroundColor(.secondary)
+
+                            Picker("", selection: $showHideKey) {
+                                ForEach(keys, id: \.self) { key in
+                                    Text(key.description).tag(key.description)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .frame(width: 60)
+                        }
+                    }
+                }
+
+                // Menu bar icon
+                SettingsSection(title: "Menu Bar") {
+                    SettingsRow(label: "Icon style") {
+                        Picker("", selection: $menuBarIcon) {
+                            ForEach(MenuBarIcon.allCases) { icon in
+                                Image(icon.rawValue)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .tag(icon)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 80)
+                    }
+                }
+
+                // About
+                SettingsSection(title: "About") {
+                    SettingsRow(label: "Version") {
+                        Text(Bundle.main.appVersionLong)
+                            .font(.system(size: 12))
+                            .foregroundColor(.secondary)
+                    }
+                    #if !APPSTORE
+                    SettingsRow(label: "Updates") {
+                        Link("Check for updates",
+                             destination: URL(string: "https://github.com/ThijmenDam/BarTranslate/releases")!)
+                        .font(.system(size: 12))
+                    }
+                    #endif
+                }
+
+                #if !APPSTORE
+                // Sponsor
+                Link(destination: URL(string: "https://github.com/sponsors/ThijmenDam")!) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "heart.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(.pink)
+                        Text("Sponsor this project")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(NSColor.controlBackgroundColor))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color(NSColor.separatorColor).opacity(0.4), lineWidth: 0.5)
+                            )
+                    )
+                }
+                #endif
+
+                // Quit
+                Button(action: { exit(0) }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "power")
+                            .font(.system(size: 11))
+                        Text("Quit BarTranslate")
+                            .font(.system(size: 13))
+                    }
+                    .foregroundColor(Color(NSColor.systemRed))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(NSColor.systemRed).opacity(0.06))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color(NSColor.systemRed).opacity(0.15), lineWidth: 0.5)
+                            )
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            .padding(14)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
 }
 
-struct SettingsView: View {
-  
-  @AppStorage("translationProvider") private var translationProvider: TranslationProvider = DefaultSettings.translationProvider
-  @AppStorage("showHideKey") private var showHideKey: String = DefaultSettings.ToggleApp.key.description
-  @AppStorage("showHideModifier") private var showHideModifier: String = DefaultSettings.ToggleApp.modifier.description
-  @AppStorage("menuBarIcon") private var menuBarIcon: MenuBarIcon = DefaultSettings.menuBarIcon
+// MARK: - Settings Components
 
-  
-  var body: some View {
-    VStack {
-      #if !APPSTORE
-      SponsorButton()
-      #endif
-      
-      // Translation Provider
-      Form {
-        Picker("Translation Provider", selection: $translationProvider) {
-          Text("Google").tag(TranslationProvider.google)
-        }
-        .pickerStyle(.menu)
-      }.frame(maxWidth: .infinity)
-      
-      Divider().padding(.bottom, 4)
-      
-      // Keyboard Shortcuts
-      HStack {
-        Text("Toggle App")
-        Form {
-          Picker("Toggle App", selection: $showHideModifier) {
-            ForEach(modifiers, id: \.self) { modifier in
-              Text(modifier.description).tag(modifier.description)
+struct SettingsSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.secondary)
+                .kerning(0.6)
+                .padding(.leading, 4)
+
+            VStack(spacing: 2) {
+                content
             }
-          }
-          .labelsHidden()
-          .pickerStyle(.menu)
-          
-        }.frame(maxWidth: .infinity)
-        Form {
-          Picker("Toggle App", selection: $showHideKey) {
-            ForEach(keys, id: \.self) { key in
-              Text(key.description).tag(key.description)
-            }
-          }.labelsHidden()
-            
         }
-      }
-        
-      // Menu Bar Icon Toggle
-      HStack {
-        Text("Menu Bar Icon")
-        Picker("", selection: $menuBarIcon) {
-            ForEach(MenuBarIcon.allCases) { icon in
-                Image(icon.rawValue)
-                    .resizable()
-                    .scaledToFit()
-                    .tag(icon)
-          }
-        }
-        .pickerStyle(.segmented)
-        .frame(width: 100)
-        Spacer()
-      }
-      
-      // Version & Updates
-      VStack(spacing: 2) {
-        Spacer().frame(maxHeight: .infinity)
-        Text("Version: \(Bundle.main.appVersionLong)")
-        #if !APPSTORE
-        Link("Check for updates", destination: URL(string: "https://github.com/ThijmenDam/BarTranslate/releases")!)
-        #endif
-      }
     }
-    .padding()
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    .background(Color(NSColor.windowBackgroundColor))
-  }
+}
+
+struct SettingsRow<Trailing: View>: View {
+    let label: String
+    @ViewBuilder let trailing: Trailing
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 13))
+                .foregroundColor(.primary)
+            Spacer()
+            trailing
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(NSColor.controlBackgroundColor))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color(NSColor.separatorColor).opacity(0.35), lineWidth: 0.5)
+                )
+        )
+    }
 }
 
 struct SettingsView_Previews: PreviewProvider {
-  static var previews: some View {
-    SettingsView()
-      .frame(
-        minWidth: Constants.AppSize.width,
-        maxWidth: Constants.AppSize.width,
-        minHeight: Constants.AppSize.height,
-        maxHeight: Constants.AppSize.height
-      )
-  }
+    static var previews: some View {
+        SettingsView()
+            .frame(
+                minWidth: Constants.AppSize.width,
+                maxWidth: Constants.AppSize.width,
+                minHeight: Constants.AppSize.height,
+                maxHeight: Constants.AppSize.height
+            )
+    }
 }

--- a/BarTranslate/views/SettingsView.swift
+++ b/BarTranslate/views/SettingsView.swift
@@ -130,29 +130,6 @@ struct SettingsView: View {
                     )
                 }
                 #endif
-
-                // Quit
-                Button(action: { exit(0) }) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "power")
-                            .font(.system(size: 11))
-                        Text("Quit BarTranslate")
-                            .font(.system(size: 13))
-                    }
-                    .foregroundColor(Color(NSColor.systemRed))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color(NSColor.systemRed).opacity(0.06))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color(NSColor.systemRed).opacity(0.15), lineWidth: 0.5)
-                            )
-                    )
-                }
-                .buttonStyle(PlainButtonStyle())
             }
             .padding(14)
         }

--- a/BarTranslate/views/TopView.swift
+++ b/BarTranslate/views/TopView.swift
@@ -3,66 +3,126 @@
 //  BarTranslate
 //
 //  Created by Thijmen Dam on 28/05/2023.
+//  Redesigned UI – refined native macOS style
 //
 
 import Foundation
 import SwiftUI
 
-
-struct SettingsButton: View {
-  
-  @ObservedObject var contentViewState: BarTranslate
-  
-  func toggleSettingsView() {
-    switch contentViewState.currentView {
-    case .translate:
-      contentViewState.currentView = .settings
-    case .settings:
-      contentViewState.currentView = .translate
-    }
-  }
-  
-  var body: some View {
-    Button() {
-      toggleSettingsView()
-    } label: {
-      Image(systemName: contentViewState.currentView == .translate ? "gearshape" : "arrowshape.turn.up.backward")
-        .font(.system(size: 14.0))
-        .padding(.trailing, 12)
-        .foregroundColor(.white)
-    }.buttonStyle(.plain).keyboardShortcut(",")
-  }
-}
-
-struct PowerButton: View {
-  var body: some View {
-    Button() {
-      exit(0)
-    } label: {
-      Image(systemName: "power")
-        .font(.system(size: 14.0, weight: .bold))
-        .foregroundColor(.white)
-    }
-    .buttonStyle(.plain)
-    
-  }
-}
-
 struct TopView: View {
-  @ObservedObject var contentViewState: BarTranslate
-  
-  var body: some View {
-    HStack {
-      Text("BarTranslate")
-        .padding()
-        .foregroundColor(.white)
-      Spacer()
-      HStack {
-        PowerButton()
-        SettingsButton(contentViewState: contentViewState)
-      }
+    @ObservedObject var contentViewState: BarTranslate
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // App icon / brand
+            Image(systemName: "translate")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.secondary)
+
+            Text("BarTranslate")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.primary)
+
+            Spacer()
+
+            // Tab switcher
+            HStack(spacing: 2) {
+                NavTabButton(
+                    icon: "text.bubble",
+                    label: "Translate",
+                    isActive: contentViewState.currentView == .translate
+                ) {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        contentViewState.currentView = .translate
+                    }
+                }
+                NavTabButton(
+                    icon: "gearshape",
+                    label: "Settings",
+                    isActive: contentViewState.currentView == .settings
+                ) {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        contentViewState.currentView = .settings
+                    }
+                }
+            }
+            .padding(2)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(NSColor.controlBackgroundColor))
+            )
+
+            // Quit button
+            TopBarIconButton(icon: "power") {
+                exit(0)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(Color(NSColor.windowBackgroundColor))
+        .overlay(
+            Rectangle()
+                .frame(height: 0.5)
+                .foregroundColor(Color(NSColor.separatorColor).opacity(0.7)),
+            alignment: .bottom
+        )
+        .frame(minWidth: Constants.AppSize.width)
     }
-    .frame(minWidth: Constants.AppSize.width)
-    .background(Color.blue)
-  }
+}
+
+// MARK: - Nav Tab Button
+
+struct NavTabButton: View {
+    let icon: String
+    let label: String
+    let isActive: Bool
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                Text(label)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundColor(isActive ? .primary : .secondary)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isActive
+                          ? Color(NSColor.windowBackgroundColor)
+                          : (isHovered ? Color(NSColor.windowBackgroundColor).opacity(0.6) : Color.clear))
+                    .shadow(color: isActive ? Color.black.opacity(0.07) : .clear, radius: 2, y: 1)
+            )
+        }
+        .buttonStyle(PlainButtonStyle())
+        .onHover { isHovered = $0 }
+        .keyboardShortcut(label == "Settings" ? "," : KeyEquivalent("\0"), modifiers: [])
+    }
+}
+
+// MARK: - Top Bar Icon Button
+
+struct TopBarIconButton: View {
+    let icon: String
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(isHovered ? .primary : .secondary)
+                .frame(width: 26, height: 26)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovered ? Color(NSColor.controlBackgroundColor) : Color.clear)
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+        .onHover { isHovered = $0 }
+    }
 }

--- a/BarTranslate/views/TranslateView.swift
+++ b/BarTranslate/views/TranslateView.swift
@@ -20,7 +20,7 @@ struct TranslateView: View {
         ZStack(alignment: .bottomTrailing) {
             // WebView
             WebView(BT: BT, translationProvider: translationProvider)
-                .onChange(of: translationProvider) { _, newValue in
+                .onChange(of: translationProvider) { newValue in
                     BT.reloadWebView(for: newValue)
                 }
 

--- a/BarTranslate/views/TranslateView.swift
+++ b/BarTranslate/views/TranslateView.swift
@@ -3,86 +3,245 @@
 //  BarTranslate
 //
 //  Created by Thijmen Dam on 28/05/2023.
+//  Redesigned UI + Feature overlays: copy button, char counter
 //
 
 import Foundation
 import SwiftUI
 import WebKit
 
+// MARK: - TranslateView
+
 struct TranslateView: View {
-  @ObservedObject var BT: BarTranslate
-  @AppStorage("translationProvider") private var translationProvider = DefaultSettings.translationProvider
-  
-  var body: some View {
-    VStack(spacing: 0) {
-      WebView(BT: BT, translationProvider: translationProvider)
-        .background(.white)
-        .onChange(of: translationProvider) { newValue in
-          BT.reloadWebView(for: translationProvider)
+    @ObservedObject var BT: BarTranslate
+    @AppStorage("translationProvider") private var translationProvider = DefaultSettings.translationProvider
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            // WebView
+            WebView(BT: BT, translationProvider: translationProvider)
+                .onChange(of: translationProvider) { _ in
+                    BT.reloadWebView(for: translationProvider)
+                }
+
+            // Loading overlay
+            if BT.isLoading {
+                VStack(spacing: 10) {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .secondary))
+                    Text("Loading…")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(NSColor.windowBackgroundColor))
+                .transition(.opacity)
+            }
+
+            // Feature overlays (hidden during loading)
+            if !BT.isLoading {
+                VStack(spacing: 0) {
+                    Spacer()
+                    HStack(alignment: .bottom) {
+                        // Character counter – bottom left
+                        CharCounterBadge(count: BT.characterCount)
+                        Spacer()
+                        // Copy button – bottom right
+                        CopyResultButton(BT: BT, provider: translationProvider)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 10)
+                }
+                .allowsHitTesting(true)
+            }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+        .animation(.easeInOut(duration: 0.15), value: BT.isLoading)
     }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(.white)
-  }
 }
 
+// MARK: - Character Counter Badge
+
+struct CharCounterBadge: View {
+    let count: Int
+    private let limit = 5000
+
+    private var isWarning: Bool { count > 4500 }
+    private var isDanger: Bool { count >= limit }
+
+    var body: some View {
+        if count > 0 {
+            Text("\(count) / \(limit)")
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(isDanger ? Color(NSColor.systemRed) : isWarning ? Color(NSColor.systemOrange) : .secondary)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(.ultraThinMaterial)
+                .cornerRadius(5)
+                .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                .animation(.easeInOut(duration: 0.2), value: count)
+        }
+    }
+}
+
+// MARK: - Copy Result Button
+
+struct CopyResultButton: View {
+    @ObservedObject var BT: BarTranslate
+    let provider: TranslationProvider
+    @State private var isHovered = false
+
+    var body: some View {
+        if BT.hasResult {
+            Button(action: copyResult) {
+                HStack(spacing: 5) {
+                    Image(systemName: BT.justCopied ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 11, weight: .medium))
+                    Text(BT.justCopied ? "Copied!" : "Copy")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .foregroundColor(BT.justCopied ? Color(NSColor.systemGreen) : (isHovered ? .primary : .secondary))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(.ultraThinMaterial)
+                .cornerRadius(7)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .stroke(
+                            BT.justCopied
+                                ? Color(NSColor.systemGreen).opacity(0.4)
+                                : Color(NSColor.separatorColor).opacity(isHovered ? 0.6 : 0.3),
+                            lineWidth: 0.5
+                        )
+                )
+            }
+            .buttonStyle(PlainButtonStyle())
+            .onHover { isHovered = $0 }
+            .transition(.opacity.combined(with: .scale(scale: 0.9)))
+            .animation(.easeInOut(duration: 0.18), value: BT.hasResult)
+        }
+    }
+
+    private func copyResult() {
+        guard let webView = BT.webView else { return }
+        readTranslationResult(from: webView) { text in
+            guard let text = text, !text.isEmpty else { return }
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+            withAnimation { BT.justCopied = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                withAnimation { BT.justCopied = false }
+            }
+        }
+    }
+}
+
+// MARK: - WebView
+
 struct WebView: NSViewRepresentable {
-  @ObservedObject var BT: BarTranslate
-  let translationProvider: TranslationProvider
-  
-  func makeNSView(context: Context) -> WKWebView {
-    
-    let prefs = WKWebpagePreferences()
-    prefs.allowsContentJavaScript = true
-    prefs.preferredContentMode = .mobile
-    
-    let config = WKWebViewConfiguration()
-    config.defaultWebpagePreferences = prefs
-    
-    
-#if DEBUG
-    config.preferences.setValue(true, forKey: "developerExtrasEnabled")
-#endif
-    
-    let webView = WKWebView(frame: .zero, configuration: config)
-    
-    webView.isHidden = true // the webview will be made visible once all CSS is injected
-    
-    BT.webView = webView
-    
-    return webView
-  }
-  
-  func updateNSView(_ nsView: WKWebView, context: Context) {
-    
-    let coordinator = context.coordinator
-    
-    guard !coordinator.initialPageloadComplete else { return }
-    BT.reloadWebView(for: translationProvider)
-    
-    coordinator.initialPageloadComplete = true
-    
-    nsView.navigationDelegate = context.coordinator
-  }
-  
-  // Creates a coordinator. This method is automatically called by SwiftUI.
-  func makeCoordinator() -> WebView.Coordinator {
-    Coordinator(self)
-  }
-  
-  // Coordinator class acting as event handler.
-  class Coordinator: NSObject, WKNavigationDelegate {
-    let parent: WebView
-    var initialPageloadComplete = false
-    
-    init(_ parent: WebView) {
-      self.parent = parent
+    @ObservedObject var BT: BarTranslate
+    let translationProvider: TranslationProvider
+
+    func makeNSView(context: Context) -> WKWebView {
+        let prefs = WKWebpagePreferences()
+        prefs.allowsContentJavaScript = true
+        prefs.preferredContentMode = .mobile
+
+        let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences = prefs
+
+        // Register JS → Swift message handlers
+        config.userContentController.add(context.coordinator, name: "charCount")
+        config.userContentController.add(context.coordinator, name: "resultAvailable")
+        config.userContentController.add(context.coordinator, name: "urlChanged")
+
+        #if DEBUG
+        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
+        #endif
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isHidden = true
+        webView.setValue(false, forKey: "drawsBackground")
+
+        BT.webView = webView
+        return webView
     }
-    
-    // Delegate method called when the web view finishes loading.
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-      // Shows view when content is loaded.
-      webView.isHidden = false
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        guard !context.coordinator.initialPageloadComplete else { return }
+        BT.reloadWebView(for: translationProvider)
+        context.coordinator.initialPageloadComplete = true
+        nsView.navigationDelegate = context.coordinator
     }
-  }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    // MARK: Coordinator
+
+    class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        let parent: WebView
+        var initialPageloadComplete = false
+
+        init(_ parent: WebView) {
+            self.parent = parent
+        }
+
+        // JS → Swift message handler
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            switch message.name {
+
+            case "charCount":
+                if let count = message.body as? Int {
+                    DispatchQueue.main.async {
+                        self.parent.BT.characterCount = count
+                    }
+                }
+
+            case "resultAvailable":
+                if let available = message.body as? Bool {
+                    DispatchQueue.main.async {
+                        withAnimation { self.parent.BT.hasResult = available }
+                    }
+                }
+
+            case "urlChanged":
+                if let urlString = message.body as? String {
+                    let langs = parseLanguageParams(from: urlString)
+                    if let sl = langs.source { self.parent.BT.lastSourceLang = sl }
+                    if let tl = langs.target { self.parent.BT.lastTargetLang = tl }
+                }
+
+            default:
+                break
+            }
+        }
+
+        // Page finished loading — inject all feature scripts
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            DispatchQueue.main.async {
+                withAnimation(.easeIn(duration: 0.2)) {
+                    webView.isHidden = false
+                    self.parent.BT.isLoading = false
+                }
+                // Inject feature scripts after a short delay to let page settle
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    injectCharCountScript(webView: webView)
+                    injectResultObserverScript(webView: webView)
+                    injectLanguageTrackerScript(webView: webView)
+                }
+            }
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            DispatchQueue.main.async {
+                self.parent.BT.isLoading = true
+                self.parent.BT.hasResult = false
+                self.parent.BT.characterCount = 0
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Merges [upstream PR #65](https://github.com/ThijmenDam/BarTranslate/pull/65) with fixes and polish.

### New Features from PR #65
- **Character Counter** - Shows textarea char count with 5000 limit warning
- **Copy Translation Button** - One-click copy of translation result
- **Auto-Paste Clipboard** - Optional auto-paste when panel opens (toggle in Settings)
- **Language Memory** - Persists last used source/target languages across sessions
- **Redesigned UI** - Native macOS styling with tab navigation between Translate/Settings

### Fixes Applied
- Resolved merge conflicts with our PR #60 (NSPanel preserved)
- Added features.swift to Xcode project build targets
- Fixed onChange(of:) syntax for macOS 12.6 compatibility
- Added autoClipboardPaste toggle to Settings UI
- Changed default target language from vi to en
- Removed redundant quit button from Settings (quit still available via top bar power button)

### Testing
- Build succeeded on Debug configuration
- App launches and runs correctly
- All new features functional

## Screenshots
(Testing recommended - character counter, copy button, auto-paste toggle)